### PR TITLE
Add default fractional zoom options

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -105,7 +105,10 @@ require('./popup.js');
 MapExt = L.Map.extend({
   options: {
     bounceAtZoomLimits: false,
-    worldCopyJump: true
+    wheelPxPerZoomLevel: 120,
+    worldCopyJump: true,
+    zoomDelta: 0.5,
+    zoomSnap: 0.5
   },
   initialize: function (options) {
     var baseLayerSet = false;


### PR DESCRIPTION
This introduces a CSS issue with `L.outerspatial.control.zoomdisplayControl` when displaying decimal numbers.