### PR TITLE
Test if popup is open before opening new popup

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -475,18 +475,16 @@ MapExt = L.Map.extend({
                 }
               }
 
-              if (actual.length) {
-                if (me._popup === null || typeof me._popup === 'undefined') {
-                  var popup = L.outerspatial.popup({
-                    autoPanPaddingTopLeft: util._getAutoPanPaddingTopLeft(me.getContainer()),
-                    maxHeight: (detectAvailablePopupSpace ? util._getAvailableVerticalSpace(me) - 84 : null),
-                    maxWidth: (detectAvailablePopupSpace ? util._getAvailableHorizontalSpace(me) - 77 : null)
-                  });
+              if (actual.length && !me._popup) {
+                var popup = L.outerspatial.popup({
+                  autoPanPaddingTopLeft: util._getAutoPanPaddingTopLeft(me.getContainer()),
+                  maxHeight: (detectAvailablePopupSpace ? util._getAvailableVerticalSpace(me) - 84 : null),
+                  maxWidth: (detectAvailablePopupSpace ? util._getAvailableHorizontalSpace(me) - 77 : null)
+                });
 
-                  popup
-                    .setContent(popup._handleResults(actual, me.options.popup))
-                    .setLatLng(latLng).openOn(me);
-                }
+                popup
+                  .setContent(popup._handleResults(actual, me.options.popup))
+                  .setLatLng(latLng).openOn(me);
               }
             }
           }

--- a/src/map.js
+++ b/src/map.js
@@ -476,15 +476,17 @@ MapExt = L.Map.extend({
               }
 
               if (actual.length) {
-                var popup = L.outerspatial.popup({
-                  autoPanPaddingTopLeft: util._getAutoPanPaddingTopLeft(me.getContainer()),
-                  maxHeight: (detectAvailablePopupSpace ? util._getAvailableVerticalSpace(me) - 84 : null),
-                  maxWidth: (detectAvailablePopupSpace ? util._getAvailableHorizontalSpace(me) - 77 : null)
-                });
+                if (me._popup === null || typeof me._popup === 'undefined') {
+                  var popup = L.outerspatial.popup({
+                    autoPanPaddingTopLeft: util._getAutoPanPaddingTopLeft(me.getContainer()),
+                    maxHeight: (detectAvailablePopupSpace ? util._getAvailableVerticalSpace(me) - 84 : null),
+                    maxWidth: (detectAvailablePopupSpace ? util._getAvailableHorizontalSpace(me) - 77 : null)
+                  });
 
-                popup
-                  .setContent(popup._handleResults(actual, me.options.popup))
-                  .setLatLng(latLng).openOn(me);
+                  popup
+                    .setContent(popup._handleResults(actual, me.options.popup))
+                    .setLatLng(latLng).openOn(me);
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes issue related to #28 in which popups were out of order in respect to layer z index. Specifically when geojson vectors were drawn inside cartodb polygon (example provided by @ryanbranciforte). 

Closes #28.  Let's keep trailheadlabs/outerspatial#1267 for builder UI overlay ordering enhancement discussion.